### PR TITLE
feat: Introduced throttling on GitHub API calls

### DIFF
--- a/gulpfile.js/metadata.json
+++ b/gulpfile.js/metadata.json
@@ -1,7 +1,8 @@
 {
   "environmentVariables": [
-    "GH_API_USERNAME",
-    "GH_API_TOKEN"
+    "GH_API_CONCURRENCY_LIMIT",
+    "GH_API_TOKEN",
+    "GH_API_USERNAME"
   ],
   "sources": [
     {

--- a/lib/transform/get-repository-metadata.js
+++ b/lib/transform/get-repository-metadata.js
@@ -1,3 +1,4 @@
+const Promise = require('bluebird');
 const YAML = require('js-yaml');
 
 const { getGithubRepositoryMetadata } = require('../repo');
@@ -6,29 +7,46 @@ const { logger } = require('../util');
 /**
  * Retrieve metadata from all GitHub repositories listed in tools stream
  *
+ * Note this uses the Bluebird Promise to provide access to the concurrency
+ * limit on the map function. This is important as it allows the calls to the
+ * GitHub API to be regulated
+ *
  * @param {string} rawNormalisedData Raw YAML data from Gulp file stream
  * @returns {string} Raw YAML data to return to Gulp stream
  */
 module.exports = async (rawNormalisedData) => {
   logger(__filename, 'getRepositoryMetadata');
 
-  const normalisedData = YAML.load(rawNormalisedData);
-  const enrichedData = await Promise.all(normalisedData
-    .map(async (source) => {
-      if (source.repository && typeof source.repository === 'string' && source.repository.match(/github\.com/)) {
-        logger(`Retrieving GitHub metadata for: ${source.repository}`);
-        const metadata = await getGithubRepositoryMetadata(
-          source.repository,
-          process.env.GH_API_USERNAME,
-          process.env.GH_API_TOKEN,
-          source.repositoryMetadata,
-        );
-        logger(`Successfully retrieved GitHub metadata for: ${source.repository}`);
-        return { ...source, ...metadata };
-      }
+  const concurrency = parseInt(process.env.GH_API_CONCURRENCY_LIMIT);
 
-      return source;
-    }));
+  if (!concurrency || Number.isNaN(concurrency)) {
+    throw new Error('Concurrency limit is not set correctly or is not a number');
+  }
+
+  logger(`Concurrency limit for this run is set to ${concurrency}`);
+
+  const normalisedData = YAML.load(rawNormalisedData);
+  const enrichedData = await Promise.all(
+    Promise.map(
+      normalisedData,
+      async (source) => {
+        if (source.repository && typeof source.repository === 'string' && source.repository.match(/github\.com/)) {
+          logger(`Retrieving GitHub metadata for: ${source.repository}`);
+          const metadata = await getGithubRepositoryMetadata(
+            source.repository,
+            process.env.GH_API_USERNAME,
+            process.env.GH_API_TOKEN,
+            source.repositoryMetadata,
+          );
+          logger(`Successfully retrieved GitHub metadata for: ${source.repository}`);
+          return { ...source, ...metadata };
+        }
+
+        return source;
+      },
+      { concurrency },
+    ),
+  );
 
   return YAML.dump(enrichedData);
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "ajv": "^8.10.0",
     "axios": "^0.24.0",
     "bayes": "^1.0.0",
+    "bluebird": "^3.7.2",
     "fancy-log": "^1.3.3",
     "graphql": "14",
     "graphql-request": "^3.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -887,6 +887,11 @@ blob@0.0.5:
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.5.tgz#d680eeef25f8cd91ad533f5b01eed48e64caf683"
   integrity sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==
 
+bluebird@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
+  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
This is a simple means for ensuring that calls to the GitHub API do not "swamp" the interface. Dispatching all API calls in one hit appears to cause sporadic 403s to be returned.

It uses the Bluebird Promise to access `Promise.map` and use the `concurrency` parameter to regulate the number of promises dispatched at any one time. The number is controlled by the GitHub Actions secret (no need to be a secret really, but this seemed the easiest way) `GH_API_CONCURRENCY_LIMIT`. This value can therefore be tweaked as required without necessitating a code change.