### PR TITLE
fix: Updated watchers source property

### DIFF
--- a/lib/repo/github.js
+++ b/lib/repo/github.js
@@ -65,7 +65,7 @@ module.exports = async (
     { source: '$.data.language', target: 'language' },
     { source: '$.data.archived', target: 'archived' },
     { source: '$.data.stargazers_count', target: 'stars' },
-    { source: '$.data.watchers_count', target: 'watchers' },
+    { source: '$.data.subscribers_count', target: 'watchers' },
     { source: '$.data.forks', target: 'forks' },
     { source: '$.data.organization.login', target: 'owner' },
     { source: '$.data.organization.avatar_url', target: 'logo' },


### PR DESCRIPTION
Simple change to use the `subscribers_count` property as the source for `watchers` (note have stuck with `watchers` rather than `subscribers` as this is the *lingua franca* of the web interface