### PR TITLE
fix: typo in index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -44,7 +44,7 @@
 
           <h2
             class="text-gray-700 font-heading text-lg leading-relaxed tracking-body font-regular mb-10 max-w-4xl mx-auto">
-            A collection of open-source and commerical tools for creating your APIs with OpenAPI
+            A collection of open-source and commercial tools for creating your APIs with OpenAPI
             <br>
             Sourced from and published for the community
           </h2>


### PR DESCRIPTION
commerical -> commercial