### PR TITLE
feat: Added Issue template for adding a tool to the repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/add_tool_request.md
+++ b/.github/ISSUE_TEMPLATE/add_tool_request.md
@@ -1,0 +1,26 @@
+---
+name: Add tool to repository
+about: Update the master repository file with a tool not found in data sources
+title: ""
+labels: ""
+assignees: ""
+---
+
+> **Please use this template for tools that cannot be tagged on GitHub. If your tool is on GitHub use the `openapi3` and `openapi31` tags to allow your data to be collected automatically.**
+
+## Tool Properties
+
+> **Please replace all placeholders marked in bold in the bullets below with the requested information. Use plain text for your information.**
+
+- Display name: **Enter the display name for the tool in the repository**
+- Description: **Provide a description of your tool. This will provide users with valuable information about your tool and be used to as a means to classify your tool correctly.**
+- Repository: **If you tool is open source but not on GitHub please provide a link to your repository.**
+- Homepage: **Provide a link to your homepage. If you have provided a repository you can leave this blank if you wish.**
+
+## OpenAPI Versions
+
+> **Please indicate the versions of OpenAPI supported by your tool by marking them true or false below.**
+
+- 3.1: false
+- 3.0: false
+- 2.0: false


### PR DESCRIPTION
Adding a new issue template to allow tools not found in source repositories to be added to the repository in a structured way i.e. avoiding manual updates to `src/_data/tools.yaml`.

Adding this template precedes further work to automatically process and merge tickets of this type to the repository (as described in #67)