### PR TITLE
Updates Openapi Json Schema generator

### DIFF
--- a/docs/categories/code-generators.html
+++ b/docs/categories/code-generators.html
@@ -152,7 +152,7 @@
                         <a target="_blank" href=https://github.com/openapi-json-schema-tools/openapi-json-schema-generator>Link</a>
                       
                     </td>
-                    <td class="px-4 py-2">No</td>
+                    <td class="px-4 py-2">Yes</td>
                     <td class="px-4 py-2">Yes</td>
                     <td class="px-4 py-2">No</td>
                     <td class="px-4 py-2">57</td>

--- a/docs/categories/code-generators.html
+++ b/docs/categories/code-generators.html
@@ -141,7 +141,7 @@
                   
                   <tr class="border-b transition duration-300 ease-in-out hover:bg-neutral-100 dark:border-neutral-500 dark:hover:bg-neutral-200 text-black">
                     <td scope="row" class="px-4 py-2 whitespace-nowrap">OpenAPI JSON Schema Generator</td>
-                    <td class="px-4 py-2"> OpenAPI JSON Schema Generator allows auto-generation of API client libraries with a focus on JSON schema given an OpenAPI Spec</td>
+                    <td class="px-4 py-2"> OpenAPI JSON Schema Generator allows auto-generation of API client libraries with a focus on JSON schema given an OpenAPI Spec. Python code generation + documentation is included.</td>
                     <td class="px-4 py-2">
                       
                         <a target="_blank" href=https://github.com/openapi-json-schema-tools/openapi-json-schema-generator>Link</a>


### PR DESCRIPTION
Updates Openapi Json Schema generator
Openapi v3.1.0 is now supported in that project per the latest release:
https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/releases/tag/3.1.0