### PR TITLE
feat: Remove IMPLEMENTATIONS.md reference from metadata

### DIFF
--- a/gulpfile.js/metadata.json
+++ b/gulpfile.js/metadata.json
@@ -8,11 +8,6 @@
   ],
   "sources": [
     {
-      "title": "IMPLEMENTATIONS.md",
-      "url": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/IMPLEMENTATIONS.md",
-      "processor": "../processors/openapi-implementations-md-processor.js"
-    },
-    {
       "title": "https://openapi.tools/",
       "url": "https://raw.githubusercontent.com/apisyouwonthate/openapi.tools/master/_data/tools.yml",
       "processor": "../processors/openapi-tools-processor.js"


### PR DESCRIPTION
As described, `IMPLEMENTATIONS.md` is no longer a valid source and has therefore been removed from `metadata.json`.

The processor library is retained in case this data source is reinstated.